### PR TITLE
Port sync to message system, add MochaJS tests to sync, split into sync, chat, and admin servers, fix MySQL edge case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 config.js
 *.log
 log.txt
+.nyc_output

--- a/.nyc_output/processinfo/index.json
+++ b/.nyc_output/processinfo/index.json
@@ -1,0 +1,1 @@
+{"processes":{"b033106d-c752-4345-9ded-93692cd25683":{"parent":null,"children":[]}},"files":{"C:\\Users\\Desktop\\Documents\\GitHub - gelic-idealab\\komodo-relay\\sync.js":["b033106d-c752-4345-9ded-93692cd25683"],"C:\\Users\\Desktop\\Documents\\GitHub - gelic-idealab\\komodo-relay\\config.js":["b033106d-c752-4345-9ded-93692cd25683"]},"externalIds":{}}

--- a/config.template.js
+++ b/config.template.js
@@ -13,14 +13,6 @@ module.exports = {
         subscriptionKey: "",
         serviceRegion: ""
     },
-    sync: {
-        POS_FIELDS: 14,
-        POS_BYTES_PER_FIELD: 4,
-        POS_COUNT: 10000,
-        INT_FIELDS: 7,
-        INT_BYTES_PER_FIELD: 4,
-        INT_COUNT: 128
-    },
     capture: {
         path: './captures/',
     },

--- a/serve.js
+++ b/serve.js
@@ -55,7 +55,6 @@ const printFormat = printf(({ level, message, timestamp }) => {
 });
 
 const logger = createLogger({
-
     format: combine(
 
         timestamp(),
@@ -73,10 +72,19 @@ const logger = createLogger({
 let pool;
 
 if (config.db.host && config.db.host != "") {
-
     pool = mysql.createPool(config.db);
-    logger.info(`Database pool created.`);
 
+    testQuery = pool.query(`SHOW TABLES;`, (err, res) => {
+        if (err) { 
+            logger.error(err);
+
+            process.exit();
+        }
+
+        else { logger.info(`Database initialized with ${res.length} tables.`); }
+    });
+
+    logger.info(`Database pool created: host: ${config.db.host}, database: ${config.db.database}.`);
 }
 
 // relay server

--- a/serve.js
+++ b/serve.js
@@ -75,6 +75,7 @@ let pool;
 if (config.db.host && config.db.host != "") {
 
     pool = mysql.createPool(config.db);
+    logger.info(`Database pool created.`);
 
 }
 

--- a/sync.js
+++ b/sync.js
@@ -41,12 +41,10 @@ const fs = require('fs');
 const path = require('path');
 
 function positionChunkSize () {
-
     return config.sync.POS_FIELDS * config.sync.POS_BYTES_PER_FIELD;
 }
 
 function interactionChunkSize () {
-
     return config.sync.INT_FIELDS * config.sync.INT_BYTES_PER_FIELD;
 }
 
@@ -55,7 +53,6 @@ function interactionChunkSize () {
 // Courtesy of Casey Foster on Stack Overflow
 // https://stackoverflow.com/a/14368628
 function compareKeys(a, b) {
-
     var aKeys = Object.keys(a).sort();
 
     var bKeys = Object.keys(b).sort();
@@ -64,21 +61,17 @@ function compareKeys(a, b) {
 }
 
 module.exports = {
-
     // write buffers are multiples of corresponding chunks
     positionWriteBufferSize: function () {
-    
         return config.sync.POS_COUNT * positionChunkSize();
     },
     
     // write buffers are multiples of corresponding chunks
     interactionWriteBufferSize: function () {
-    
         return config.sync.INT_COUNT * interactionChunkSize();
     },
 
     logInfoSessionClientSocketAction: function (session_id, client_id, socket_id, action) {
-
         if (session_id == null) {
             session_id = "---";
         }
@@ -100,7 +93,6 @@ module.exports = {
         }
 
         if (!this.logger) {
-
             return;
         }
 
@@ -108,7 +100,6 @@ module.exports = {
     },
 
     logErrorSessionClientSocketAction: function (session_id, client_id, socket_id, action) {
-
         if (session_id == null) {
             session_id = "---";
         }
@@ -130,7 +121,6 @@ module.exports = {
         }
 
         if (!this.logger) {
-
             return;
         }
 
@@ -138,7 +128,6 @@ module.exports = {
     },
 
     logWarningSessionClientSocketAction: function (session_id, client_id, socket_id, action) {
-
         if (session_id == null) {
             session_id = "---";
         }
@@ -160,7 +149,6 @@ module.exports = {
         }
 
         if (!this.logger) {
-
             return;
         }
 
@@ -218,6 +206,7 @@ module.exports = {
                     wstream.close();
                     pos_writer.cursor = 0;
                 }
+
                 let int_writer = session.writers.int;
                 if (int_writer.cursor > 0) {
                     let path = this.getCapturePath(session_id, session.recordingStart, 'int');
@@ -239,7 +228,6 @@ module.exports = {
                         }
                     );
                 }
-
             } else if (session && !session.isRecording) {
                 if (this.logger) this.logger.warn(`Requested to end session capture, but capture is already ended: ${session_id}`);
             } else {
@@ -250,26 +238,25 @@ module.exports = {
 
     record_message_data: function (data) {
         if (!data) {
+            this.logErrorSessionClientSocketAction(null, null, null, `data was null`);
 
-            throw new ReferenceError ("data was null");
-            
-            
+            return;
         }
 
         let session_id = data.session_id;
 
         if (!session_id) {
+            this.logErrorSessionClientSocketAction(null, null, null, `Tried to record message data, but data.session_id was null`);
 
-            throw new ReferenceError ("session was null");
-            
+            return;
         }
         
         let client_id = data.client_id;
 
         if (!client_id) {
+            this.logErrorSessionClientSocketAction(session_id, null, null, `Tried to record message data, but data.session_id was null`);
 
-            throw new ReferenceError ("client_id was null");
-            
+            return;
         }
 
         // TODO(rob): message data recording
@@ -326,8 +313,6 @@ module.exports = {
 
         // check that all params are valid
         if (capture_id && start) {
-
-
             // TODO(rob): Mar 3 2021 -- audio playback on hold to focus on data. 
             // build audio file manifest
             // if (this.logger) this.logger.info(`Buiding audio file manifest for capture replay: ${playback_id}`)
@@ -366,7 +351,6 @@ module.exports = {
             //     });
             // });
 
-
             // position streaming
             let capturePath = this.getCapturePath(capture_id, start, 'pos');
             let stream = fs.createReadStream(capturePath, { highWaterMark: positionChunkSize() });
@@ -376,7 +360,6 @@ module.exports = {
 
             // position data emit loop
             stream.on('data', function(chunk) {
-
                 stream.pause();
 
                 // start data buffer loop
@@ -385,6 +368,7 @@ module.exports = {
                 for (var i = 0; i < farr.length; i++) {
                     farr[i] = buff.readFloatLE(i * 4);
                 }
+
                 var arr = Array.from(farr);
 
                 let timer = setInterval( () => {
@@ -398,6 +382,7 @@ module.exports = {
                             arr[2] = 90000 + arr[2];
                             arr[3] = 90000 + arr[3];
                         }
+
                         // if (!audioStarted) {
                         //     // HACK(rob): trigger clients to begin playing buffered audio 
                         //     audioStarted = true;
@@ -432,10 +417,10 @@ module.exports = {
                 for (var i = 0; i < farr.length; i++) {
                     farr[i] = buff.readInt32LE(i * 4);
                 }
+
                 var arr = Array.from(farr);
 
                 let timer = setInterval( () => {
-
                     // console.log(`=== INT === current seq ${current_seq}; arr seq ${arr[INT_FIELDS-1]}`);
 
                     if (arr[INT_FIELDS-1] <= current_seq) {
@@ -444,7 +429,6 @@ module.exports = {
                         clearInterval(timer);
                     }
                 }, 1);
-
             });
 
             istream.on('error', function(err) {
@@ -460,14 +444,11 @@ module.exports = {
     },
 
     isValidRelayPacket: function (data) {
-
         let session_id = data[1];
 
         let client_id = data[2];
         
-        if (session_id && client_id) 
-        {  
-
+        if (session_id && client_id)  {
             let session = this.sessions.get(session_id);
 
             if (!session) {
@@ -477,9 +458,7 @@ module.exports = {
             // check if the incoming packet is from a client who is valid for this session
 
             for (let i = 0; i < session.clients.length; i += 1) {
-
                 if (client_id == session.clients[i]) {
-
                     return true;
                 }
             }
@@ -489,10 +468,10 @@ module.exports = {
     },
 
     writeRecordedRelayData: function (data) {
-
         if (!data) {
-
-            throw new ReferenceError ("data was null");
+            this.logErrorSessionClientSocketAction(null, null, null, `Tried to write recorded relay data, but data was null`);
+            
+            return;
         }
 
         let session_id = data[1];
@@ -500,8 +479,9 @@ module.exports = {
         let session = this.sessions.get(session_id);
 
         if (!session) {
+            this.logErrorSessionClientSocketAction(null, null, null, `Tried to write recorded relay data, but data was null`);
 
-            throw new ReferenceError ("session was null");
+            return;
         }
 
         if (!session.isRecording) {
@@ -515,7 +495,6 @@ module.exports = {
         let writer = session.writers.pos;
 
         if (positionChunkSize() + writer.cursor > writer.buffer.byteLength) {
-
             // if buffer is full, dump to disk and reset the cursor
             let path = this.getCapturePath(session_id, session.recordingStart, 'pos');
 
@@ -529,7 +508,6 @@ module.exports = {
         }
 
         for (let i = 0; i < data.length; i++) {
-
             writer.buffer.writeFloatLE(data[i], (i*POS_BYTES_PER_FIELD) + writer.cursor);
         }
 
@@ -537,10 +515,10 @@ module.exports = {
     },
 
     updateSessionState: function (data) {
-
-        if (!data) {
-
-            throw new ReferenceError ("data was null");
+        if (!data || data.length < 5) {
+            this.logErrorSessionClientSocketAction(null, null, null, `Tried to update session state, but data was null or not long enough`);
+            
+            return;
         }
 
         let session_id = data[1];
@@ -548,27 +526,23 @@ module.exports = {
         let session = this.sessions.get(session_id);
 
         if (!session) {
+            this.logErrorSessionClientSocketAction(session_id, null, null, `Tried to update session state, but there was no such session`);
 
-            throw new ReferenceError ("session was null");
+            return;
         }
 
         // update session state with latest entity positions
         let entity_type = data[4];
 
         if (entity_type == 3) {
-
             let entity_id = data[3];
 
             let i = session.entities.findIndex(e => e.id == entity_id);
 
             if (i != -1) {
-
                 session.entities[i].latest = data;
-
             } else {
-
                 let entity = {
-
                     id: entity_id,
                     latest: data,
                     render: true,
@@ -633,6 +607,7 @@ module.exports = {
                     session.entities.push(entity);
                 }
             }
+
             // entity should stop being rendered
             if (interaction_type == INTERACTION_RENDER_END) {
                 let i = session.entities.findIndex(e => e.id == target_id);
@@ -648,10 +623,12 @@ module.exports = {
                     session.entities.push(entity);
                 }
             }
+
             // scene has changed
             if (interaction_type == INTERACTION_SCENE_CHANGE) {
                 session.scene = target_id;
             }
+
             // entity is locked
             if (interaction_type == INTERACTION_LOCK) {
                 let i = session.entities.findIndex(e => e.id == target_id);
@@ -667,6 +644,7 @@ module.exports = {
                     session.entities.push(entity);
                 }
             }
+
             // entity is unlocked
             if (interaction_type == INTERACTION_LOCK_END) {
                 let i = session.entities.findIndex(e => e.id == target_id);
@@ -685,7 +663,6 @@ module.exports = {
 
             // write to file as binary data
             if (session.isRecording) {
-                
                 // calculate and write session sequence number
                 data[INT_FIELDS-1] = data[INT_FIELDS-1] - session.recordingStart;
                 
@@ -700,20 +677,27 @@ module.exports = {
                     wstream.close();
                     writer.cursor = 0;
                 }
+
                 for (let i = 0; i < data.length; i++) {
                     writer.buffer.writeInt32LE(data[i], (i*INT_BYTES_PER_FIELD) + writer.cursor);
                 }
+
                 writer.cursor += interactionChunkSize();
             }
         }
     },
 
     handleState: function (socket, data) {
+        if(!socket) {
+            this.logErrorSessionClientSocketAction(null, null, null, `tried to handle state, but socket was null`);
+
+            return { session_id: -1, state: null };
+        }
 
         if (!data) {
-            
-            throw new ReferenceError ("data was null");
-            
+            this.logErrorSessionClientSocketAction(null, null, socket.id, `tried to handle state, but data was null`);
+        
+            return { session_id: -1, state: null };
         }
             
         let session_id = data.session_id;
@@ -723,7 +707,6 @@ module.exports = {
         this.logInfoSessionClientSocketAction(session_id, client_id, socket.id, `State: ${JSON.stringify(data)}`);
             
         if (!session_id || !client_id) {
-
             this.connectionAuthorizationErrorAction(socket, "You must provide a session ID and a client ID in the URL options.");
 
             return { session_id: -1, state: null };
@@ -734,7 +717,6 @@ module.exports = {
         let session = this.sessions.get(session_id);
 
         if (!session) {
-
             this.stateErrorAction(socket, "The session was null, so no state could be found.");
 
             return { session_id: -1, state: null };
@@ -744,15 +726,12 @@ module.exports = {
 
         // check requested api version
         if (version === 2) {
-
             state = {
-
                 clients: session.clients,
                 entities: session.entities,
                 scene: session.scene,
                 isRecording: session.isRecording
             };
-
         } else { // version 1 or no api version indicated
 
             let entities = [];
@@ -760,17 +739,14 @@ module.exports = {
             let locked = [];
 
             for (let i = 0; i < session.entities.length; i++) {
-
                 entities.push(session.entities[i].id);
 
                 if (session.entities[i].locked) {
-
                     locked.push(session.entities[i].id);
                 }
             }
 
             state = {
-                
                 clients: session.clients,
                 entities: entities,
                 locked: locked,
@@ -781,77 +757,75 @@ module.exports = {
 
         return { session_id, state };
     },
-    
+
+    // returns true on success and false on failure    
     addClientToSession: function (session, client_id, do_create_session) {
-
         if (session == null && !do_create_session) {
+            this.logErrorSessionClientSocketAction(null, client_id, null, `tried to add client to session, but session was null and do_create_session was false`);
 
-            throw new ReferenceError ("session was null");
+            return false;
         }
 
         if (session == null && do_create_session) {
-
             session = this.createSession();
         }
 
         if (session.clients == null || 
             typeof session.clients === "undefined" || 
             session.clients.length == 0) {
-
             session.clients = [ client_id ];
+
+            return true;
+        }
+
+        session.clients.push(client_id);
+
+        return true;
+    },
+
+    removeDuplicateClientsFromSession: function (session, client_id) {
+        if (session == null) {
+            this.logErrorSessionClientSocketAction(null, client_id, null, `tried to remove duplicate client from session, but session was null`);
 
             return;
         }
 
-        session.clients.push(client_id);
-    },
-
-    removeDuplicateClientsFromSession: function (session, client_id) {
-
-        if (session == null) {
-
-            throw new ReferenceError ("session was null");
-        }
-
         if (session.clients == null) {
+            this.logErrorSessionClientSocketAction(session.id, client_id, null, `tried to remove duplicate client from session, but session.clients was null`);
 
-            throw new Error ("session.clients was null");
+            return;
         }
 
         if (session.clients.length == 0) {
-            
             return;
         }
 
         const first_instance = session.clients.indexOf(client_id);
 
         for (let i = 0; i < session.clients.length; i += 1) {
-
             if (i != first_instance && session.clients[i] == client_id) {
-
                 session.clients.splice(i, 1);
-
             }
         }
     },
 
     removeClientFromSession: function (session, client_id) {
-
         if (session == null) {
+            this.logErrorSessionClientSocketAction(null, client_id, null, `tried to remove client from session, but session was null`);
 
-            throw new ReferenceError("session was null");
+            return;
         }
 
         if (session.clients == null) {
-            
-            throw new ReferenceError("session.clients was null");
+            this.logErrorSessionClientSocketAction(session.id, client_id, null, `tried to remove client from session, but session.clients was null`);
+
+            return;
         }
 
         let index = session.clients.indexOf(client_id);
 
         if (session.clients.length == 0 || 
             session.clients.indexOf(client_id) == -1) {
-
             //client_id is not in the array, so we don't need to remove it.
             this.logWarningSessionClientSocketAction(null, null, client_id, `Tried removing client from session.clients, but it was not there. Proceeding anyways.`);
 
@@ -862,24 +836,28 @@ module.exports = {
     },
 
     addSocketToSession: function (session, socket, client_id) {
-
         if (!session) {
+            this.logErrorSessionClientSocketAction(null, client_id, socket.id, `tried to add socket to session, but session was null`);
 
-            throw new ReferenceError("session was null");
+            return;
         }
 
         session.sockets[socket.id] = { client_id: client_id, socket: socket };
     },
 
+    // returns true iff socket was successfully joined to session
     handleJoin: function (err, socket, session_id, client_id, do_bump_duplicates) {
+        if (!socket) {
+            this.logErrorSessionClientSocketAction(session_id, client_id, null, `tried to handle join, but socket was null`);
+            
+            return false;
+        }
 
         if (!this.joinSessionAction) {
-            
-            throw new Error("this.disconnectAction was null");
+            this.logWarningSessionClientSocketAction(session_id, client_id, socket.id, `in handleJoin, joinSessionAction callback was not provided. Proceeding anyways.`)
         }
 
         if (err) {
-
             this.logErrorSessionClientSocketAction(session_id, client_id, socket.id, `Error joining client to session: ${err}`);
 
             return false;
@@ -888,18 +866,22 @@ module.exports = {
         let { success, session } = this.getSession(session_id);
 
         if (!success || !session) {
-
             this.logWarningSessionClientSocketAction(session_id, client_id, socket.id, "session was null when adding socket to session. Creating a session for you.");
 
             session = this.createSession(session_id);
         }
 
-        this.addClientToSession(session, client_id);
+        success = this.addClientToSession(session, client_id);
+
+        if (!success) {
+            this.logErrorSessionClientSocketAction(session_id, client_id, socket.id, `tried to handle join, but adding client to session failed.`);
+        
+            return;
+        }
 
         this.bumpDuplicateSockets(session, client_id, do_bump_duplicates, socket.id);
         
         if (do_bump_duplicates) {
-
             this.removeDuplicateClientsFromSession(session, client_id);
         }
 
@@ -914,34 +896,33 @@ module.exports = {
 
     //TODO rewrite this so that do_bump_duplicates and socket_id become ids_to_keep
     bumpDuplicateSockets: function (session, client_id, do_bump_duplicates, socket_id) {
-
         if (session == null) {
+            this.logErrorSessionClientSocketAction(null, client_id, socket_id, `tried to bump duplicate sockets, but session was null`);
 
-            throw new ReferenceError("session was null");
+            return;
         }
 
         let session_id = this.getSessionIdFromSession(session);
 
         if (this.bumpAction == null) {
-
-            throw new Error("this.bumpAction was null");
+            this.logWarningSessionClientSocketAction(session.id, client_id, socket_id, `in bumpDuplicateSockets, bumpAction callback was not provided`);
         }
         
         let sockets;
         
         if (do_bump_duplicates) {
-
             sockets = this.getSessionSocketsFromClientId(session, client_id, socket_id);
-
         } else {
-
             sockets = this.getSessionSocketsFromClientId(session, client_id, null);
         }
 
         let self = this;
+
+        if (!sockets) {
+            this.logWarningSessionClientSocketAction(session.id, client_id, socket_id, `tried to bump duplicate sockets, but result of getSessionSocketsFromClientId was null. Proceeding anyways.`);
+        }
             
         sockets.forEach((socket) => {
-        
             self.bumpAction(session_id, socket);
 
             self.removeSocketFromSession(socket, session_id, client_id);
@@ -949,9 +930,7 @@ module.exports = {
     },
 
     writeEventToConnections: function (event, session_id, client_id) {
-
         if (!this.pool) {
-
             this.logErrorSessionClientSocketAction(session_id, client_id, null, "pool was null");
 
             return;
@@ -961,61 +940,57 @@ module.exports = {
             "INSERT INTO connections(timestamp, session_id, client_id, event) VALUES(?, ?, ?, ?)", [Date.now(), session_id, client_id, event],
 
             (err, res) => {
-
                 if (err != undefined) {
-
                     this.logErrorSessionClientSocketAction(session_id, client_id, null, `Error writing ${event} event to database: ${err} ${res}`);
-
                 }
             }
         );
     },
 
+    // returns session ID on success; returns -1 on failure
     getSessionIdFromSession: function (session) {
+        let result = -1;
 
         if (session == null || typeof session === "undefined") {
-            
-            throw new Error("session was null or undefined.");
+            this.logErrorSessionClientSocketAction(null, null, null, `tried to get session ID from session, but session was null or undefined`);
+
+            return result;
         }
 
         if (typeof session !== "object") {
-            
-            throw new Error("session was not an object.");
+            this.logErrorSessionClientSocketAction(null, null, null, `tried to get session ID from session, but session was not an object`);
+
+            return result;
         }
 
         if (session.clients == null || typeof session.clients === "undefined") {
-            
-            throw new Error("session.clients was null or undefined.");
+            this.logErrorSessionClientSocketAction(session.id, null, null, `session.clients was null or undefined`);
+
+            return result;
         }
 
         if (session.sockets == null || typeof session.sockets === "undefined") {
-            
-            throw new Error("session.sockets was null or undefined.");
+            this.logErrorSessionClientSocketAction(session.id, null, null, `session.sockets was null or undefined`);
+
+            return result;
         }
 
-        let result = -1;
-
         this.sessions.forEach((candidate_session, candidate_session_id) => {
-
             if (candidate_session.clients == null || 
                 typeof candidate_session.clients === "undefined") {
-                
                 return; // return from the inner function only.
             }
     
             if (candidate_session.sockets == null || 
                 typeof candidate_session.sockets === "undefined") {
-                
                 return; // return from the inner function only.
             }
 
             if (candidate_session.sockets.size != session.sockets.size) {
-
                 return; // return from the inner function only.
             }
 
             if (compareKeys(candidate_session.sockets, session.sockets)) {
-
                 result = candidate_session_id;
             }
         });
@@ -1024,27 +999,26 @@ module.exports = {
     },
     
     getSessionSocketsFromClientId: function (session, client_id, excluded_socket_id) {
-
         if (session == null) {
-            
-            throw new ReferenceError("session was null");
+            this.logErrorSessionClientSocketAction(null, client_id, null, `tried to get session sockets from client ID, but session was null`);
+
+            return null;
         }
 
         if (session.sockets == null) {
-            
-            throw new Error("session.sockets was null");
+            this.logErrorSessionClientSocketAction(session.id, client_id, null, `tried to get session sockets from client ID, but session.sockets was null`);
+
+            return null;
         }
 
         var result = [];
 
         for (var candidate_socket_id in session.sockets) {
-
             let isCorrectId = session.sockets[candidate_socket_id].client_id == client_id;
 
             let doExclude = (session.sockets[candidate_socket_id].socket.id == excluded_socket_id);
 
             if (isCorrectId && !doExclude) {
-
                 result.push(session.sockets[candidate_socket_id].socket);
             }
         }
@@ -1052,12 +1026,11 @@ module.exports = {
         return result;
     },
 
+    // returns number of client instances of the same ID on success; returns -1 on failure;
     getNumClientInstancesForClient: function (session_id, client_id) {
-
         let session = this.sessions.get(session_id);
 
         if (session == null || session.clients == null) {
-
             this.logErrorSessionClientSocketAction(session_id, client_id, null, `Could not get number of client instances -- session was null or session.clients was null.`);
 
             return -1;
@@ -1066,9 +1039,7 @@ module.exports = {
         var count = 0;
 
         session.clients.forEach((value) => {
-
             if (value == client_id) {
-
                 count += 1;
             }
         });
@@ -1078,10 +1049,14 @@ module.exports = {
 
     // cleanup socket and client references in session state if reconnect fails
     removeSocketFromSession: function (socket, session_id, client_id) {
+        if (!socket) {
+            this.logErrorSessionClientSocketAction(session_id, client_id, null, `tried removing socket from session, but socket was null`);
+
+            return;
+        }
 
         if (!this.disconnectAction) {
-            
-            throw new Error("this.disconnectAction was null");
+            this.logWarningSessionClientSocketAction(null, client_id, socket.id, `in removeSocketFromSession, disconnectAction callback was not provided`);
         }
 
         this.disconnectAction(socket, session_id, client_id);
@@ -1090,14 +1065,12 @@ module.exports = {
         let session = this.sessions.get(session_id);
 
         if (!session) {
-            
             this.logWarningSessionClientSocketAction(session_id, client_id, socket.id, `Could not find session when trying to remove a socket from it.`);
 
             return;
         }
 
         if (!(socket.id in session.sockets)) {
-
             this.logErrorSessionClientSocketAction(session_id, client_id, socket.id, `tried removing socket from session.sockets, but it was not found.`);
 
             return;
@@ -1112,18 +1085,15 @@ module.exports = {
     },
 
     getNumClientInstances: function (session_id) {
-
         let session = this.sessions.get(session_id);
 
         if (!session) {
-
             this.logWarningSessionClientSocketAction(session_id, null, null, `tried to get number of clients for a session, but it was not found.`);
 
             return -1;
         }
 
         if (session.clients == null) {
-            
             this.logWarningSessionClientSocketAction(session_id, null, null, `the session's session.clients was null.`);
 
             return -1;
@@ -1133,20 +1103,16 @@ module.exports = {
     },
 
     try_to_end_recording: function (session_id) {
-
         let session = this.sessions.get(session_id);
 
         if (!session) {
-
             this.logWarningSessionClientSocketAction(session_id, null, null, `tried to end recording for session ${session_id}, but it was not found.`);
 
             return;
         }
 
         if (!session.isRecording) {
-
             return;
-
         }
 
         this.logInfoSessionClientSocketAction(session_id, null, null, `Stopping recording for empty session`);
@@ -1156,9 +1122,7 @@ module.exports = {
 
     // clean up session from sessions map if empty, write 
     cleanUpSessionIfEmpty: function (session_id) {
-
         if (this.getNumClientInstancesForClient(session_id) >= 0) {
-
             // don't clean up if there are still clients in the session
             return;
         }
@@ -1172,11 +1136,9 @@ module.exports = {
 
     // if a session exists, return it. Otherwise, create one with default values, register it, and return it.
     getOrCreateSession: function (session_id) {
-
         let { success, session } = this.getSession(session_id);
 
         if (success) {
-
             return session;
         }
 
@@ -1184,13 +1146,10 @@ module.exports = {
     },
 
     getSession: function (session_id) {
-
         let _session = this.sessions.get(session_id);
 
         if (_session != null && typeof _session != "undefined") {
-
             return {
-
                 success: true,
 
                 session: _session
@@ -1198,7 +1157,6 @@ module.exports = {
         }
 
         return { 
-
             success: false, 
 
             session: null 
@@ -1206,15 +1164,12 @@ module.exports = {
     }, 
 
     initialize_recording_writers: function () {
-
     },
 
     createSession: function (session_id) {
-
         this.logInfoSessionClientSocketAction(session_id, null, null, `Creating session: ${session_id}`);
 
         this.sessions.set(session_id, {
-
             sockets: {}, // socket.id -> client_id
             clients: [],
             entities: [],
@@ -1241,11 +1196,9 @@ module.exports = {
     },
 
     processReconnectionAttempt: function (err, socket, session_id, client_id) {
-
         let success = this.handleJoin(err, socket, session_id, client_id, true);
 
         if (!success) { 
-
             this.logInfoSessionClientSocketAction(session_id, client_id, socket.id, 'failed to reconnect');
 
             this.removeSocketFromSession(socket, session_id, client_id);
@@ -1260,19 +1213,15 @@ module.exports = {
         this.logInfoSessionClientSocketAction(session_id, client_id, socket.id, 'successfully reconnected');
 
         return true;
-
     },
 
     whoDisconnected: function (socket) {
-        
         for (var s in this.sessions) {
-
             const session_id = s[0];
 
             let session = s[1];
 
             if (!(socket.id in session.sockets)) {
-
                 // This isn't the right session, so keep looking.
                 continue;
             }
@@ -1287,7 +1236,6 @@ module.exports = {
         }
 
         return {
-
             session_id: null,
 
             client_id: null
@@ -1296,10 +1244,16 @@ module.exports = {
 
     // returns true if socket is still connected
     handleDisconnect: function (socket, reason) {
+        if (!socket) {
+            this.logErrorSessionClientSocketAction(null, null, null, `tried handling disconnect, but socket was null`);
+
+            return false;
+        }
 
         if (!this.reconnectAction) {
-            
-            throw new Error("this.reconnectAction was null");
+            this.logErrorSessionClientSocketAction(null, null, socket.id, `in handleDisconnect, reconnectAction callback was not provided`);
+
+            return false;
         }
 
         // Check disconnect event reason and handle
@@ -1332,13 +1286,11 @@ module.exports = {
 
         // find which session this socket is in
         for (var s of this.sessions) {
-
             let session_id = s[0];
 
             let session = s[1];
 
             if (!(socket.id in session.sockets)) {
-
                 // This isn't the right session, so keep looking.
                 continue;
             }
@@ -1348,8 +1300,7 @@ module.exports = {
             let client_id = session.sockets[socket.id].client_id;
 
             if ((knownReasons.hasOwnProperty(reason) && knownReasons[reason].doReconnect) || doReconnectOnUnknownReason) {
-
-                return this.reconnectAction(reason, socket, session_id, client_id, session); // Don't continue to check other sessions.
+                return this.reconnectAction(reason, socket, session_id, client_id, session);
             }
 
             //Disconnect the socket
@@ -1368,14 +1319,11 @@ module.exports = {
     },
 
     createCapturesDirectory: function () {
-
         if (!fs.existsSync(config.capture.path)) {
-
             this.logInfoSessionClientSocketAction(null, null, null, `Creating directory for session captures: ${config.capture.path}`);
 
             fs.mkdirSync(config.capture.path);
         }
-
     },
 
     getSessions: function () {
@@ -1383,18 +1331,15 @@ module.exports = {
     },
 
     initGlobals: function () {
-
         this.sessions = new Map();
     },
 
     init: function (io, pool, logger) {
-
         this.initGlobals();
 
         this.createCapturesDirectory();
 
         if (logger == null) {
-
             console.warn("No logger was found.");
         }
 
@@ -1403,7 +1348,6 @@ module.exports = {
         this.logInfoSessionClientSocketAction("Session ID", "Client ID", "Socket ID", "Message");
 
         if (pool == null) {
-
             if (this.logger) this.logger.warn("No MySQL Pool was found.");
         }
 
@@ -1412,23 +1356,18 @@ module.exports = {
         let self = this;
 
         if (io == null) {
-
             if (this.logger) this.logger.warn("No SocketIO server was found.");
         }
 
         this.connectionAuthorizationErrorAction = function (socket, message) {
-
             socket.emit("connectionError", message);
         };
 
         this.bumpAction = function (session_id, socket) {
-                
             self.logInfoSessionClientSocketAction(session_id, null, socket.id, `leaving session`);
 
             socket.leave(session_id.toString(), (err) => {
-
                 if (err) {
-
                     self.logErrorSessionClientSocketAction(session_id, null, socket.id, err);
 
                     return;
@@ -1438,48 +1377,39 @@ module.exports = {
             self.logInfoSessionClientSocketAction(session_id, null, socket.id, `Disconnecting: ...`);
 
             setTimeout(() => {
-
                 socket.disconnect(true);
 
                 self.logInfoSessionClientSocketAction(session_id, null, socket.id, `Disconnecting: Done.`);
-
             }, 500); // delay half a second and then bump the old socket    
         };
 
         this.joinSessionAction = function (session_id, client_id) {
-
             io.to(session_id.toString()).emit('joined', client_id);
         };
 
         this.disconnectAction = function (socket, session_id, client_id) {
-            
             // notify and log event
             socket.to(session_id.toString()).emit('disconnected', client_id);
         };
 
         this.stateErrorAction = function (socket, message) {
-
             socket.emit('stateError', message);
         };
 
         // returns true for successful reconnection
         this.reconnectAction = function (reason, socket, session_id, client_id, session) {
-    
             self.logInfoSessionClientSocketAction(session_id, client_id, socket.id, `Client was disconnected; attempting to reconnect. Disconnect reason: ${reason}, clients: ${JSON.stringify(session.clients)}`);
     
             socket.join(session_id.toString(), (err) => { 
-    
                 self.processReconnectionAttempt(err, socket, session_id, client_id);
             });
         };
 
         // main relay handler
         io.on('connection', function(socket) {
-
             self.logInfoSessionClientSocketAction(null, null, socket.id, `Session connection`);
 
             socket.on('sessionInfo', function (session_id) {
-
                 let session = self.sessions.get(session_id);
 
                 if (!session) {
@@ -1493,7 +1423,6 @@ module.exports = {
 
             //Note: "join" is our own event name, and should not be confused with socket.join. (It does not automatically listen for socket.join either.)
             socket.on('join', function(data) {
-
                 let session_id = data[0];
 
                 let client_id = data[1];
@@ -1501,7 +1430,6 @@ module.exports = {
                 self.logInfoSessionClientSocketAction(session_id, client_id, socket.id, `Asked to join`);
 
                 if (!client_id || !session_id) {
-
                     self.connectionAuthorizationErrorAction(socket, "You must provide a client ID and a session ID in the URL options.");
 
                     return;
@@ -1511,11 +1439,9 @@ module.exports = {
 
                 // relay server joins connecting client to session room
                 socket.join(session_id.toString(), (err) => { 
-
                     let success = self.handleJoin(err, socket, session_id, client_id, true); 
 
                     if (success) {
-                        
                         // write join event to database
                         self.writeEventToConnections("connect", session_id, client_id);
                     }
@@ -1523,41 +1449,30 @@ module.exports = {
             });
 
             socket.on('state', function(data) {
-
                 let { session_id, state } = self.handleState(socket, data);
 
                 if (session_id == -1 || !state) {
-
                     self.logWarningSessionClientSocketAction(session_id, null, socket.id, "state was null");
 
                     return;
                 }
 
                 try {
-
                     // emit versioned state data
                     io.to(session_id).emit('state', state);
-
                 } catch (err) {
-
-                    throw err;
-
+                    this.logErrorSessionClientSocketAction(session_id, null, socket.id, err.message)
                 }
-
             });
 
             socket.on('draw', function(data) {
-
                 let session_id = data[1];
 
                 let client_id = data[2];
 
                 if (session_id && client_id) {
-
                     socket.to(session_id.toString()).emit('draw', data);
-
                 }
-
             });
 
             // general message relay
@@ -1567,25 +1482,20 @@ module.exports = {
             // in order to update the session state accordingly. we will probably need to protect against
             // garbage values that might be passed by devs who are overwriting reserved message events.  
             socket.on('message', function(data) {
-
                 let session_id = data.session_id;
 
                 let client_id = data.client_id;
 
                 if (session_id && client_id) {
-
                     socket.to(session_id.toString()).emit('message', data);
 
                     record_message_data(data);
                 }
-
             });
 
             // client position update handler
             socket.on('update', function(data) {
-        
                 if (!self.isValidRelayPacket(data)) {  
-                    
                     return;
                 }
 
@@ -1597,44 +1507,33 @@ module.exports = {
                 self.writeRecordedRelayData(data);
 
                 self.updateSessionState(data);
-            
             });
 
             // handle interaction events
             // see `INTERACTION_XXX` declarations for type values
             socket.on('interact', function(data) {
-
                 self.handleInteraction(socket, data);
-                
             });
         
             // session capture handler
             socket.on('start_recording', function (session_id) {
-
                 self.start_recording(pool, session_id);
-
             });
                 
             socket.on('end_recording', function (session_id) {
-
                 self.end_recording(pool, session_id);
-
             });
 
             socket.on('playback', function(data) {
-
                 self.handlePlayback(io, data);
-
             });
 
             socket.on('disconnect', function (reason) {
-
                 const { session_id, client_id } = self.whoDisconnected(socket);
 
                 let didReconnect = self.handleDisconnect(socket, reason);
 
                 if (didReconnect) {
-
                     // log reconnect event with timestamp to db
                     self.writeEventToConnections("reconnect", session_id, client_id);
 

--- a/sync.js
+++ b/sync.js
@@ -854,7 +854,7 @@ module.exports = {
         }
 
         if (!this.joinSessionAction) {
-            this.logWarningSessionClientSocketAction(session_id, client_id, socket.id, `in handleJoin, joinSessionAction callback was not provided. Proceeding anyways.`)
+            this.logWarningSessionClientSocketAction(session_id, client_id, socket.id, `in handleJoin, joinSessionAction callback was not provided. Proceeding anyways.`);
         }
 
         if (err) {
@@ -1461,7 +1461,7 @@ module.exports = {
                     // emit versioned state data
                     io.to(session_id).emit('state', state);
                 } catch (err) {
-                    this.logErrorSessionClientSocketAction(session_id, null, socket.id, err.message)
+                    this.logErrorSessionClientSocketAction(session_id, null, socket.id, err.message);
                 }
             });
 

--- a/test/test-sync.js
+++ b/test/test-sync.js
@@ -80,16 +80,18 @@ describe("Sync Server: Sessions", function (done) {
             start: Date.now(),
             recordingStart: 0,
             seq: 0,
-            writers: {
-                pos: {
-                    buffer: Buffer.alloc(syncServer.positionWriteBufferSize()),
-                    cursor: 0
-                },
-                int: {
-                    buffer: Buffer.alloc(syncServer.interactionWriteBufferSize()),
-                    cursor: 0
-                }
-            }
+            // NOTE(rob): DEPRECATED, use message_buffer. 8/3/2021
+            // writers: {
+            //     pos: {
+            //         buffer: Buffer.alloc(syncServer.positionWriteBufferSize()),
+            //         cursor: 0
+            //     },
+            //     int: {
+            //         buffer: Buffer.alloc(syncServer.interactionWriteBufferSize()),
+            //         cursor: 0
+            //     }
+            // },
+            message_buffer: []
         };
         
         assert.deepStrictEqual(singularEntry[1].sockets, expectedSession.sockets);
@@ -109,7 +111,11 @@ describe("Sync Server: Sessions", function (done) {
 
         assert.deepStrictEqual(singularEntry[1].seq, expectedSession.seq);
 
-        assert.deepStrictEqual(singularEntry[1].writers, expectedSession.writers);
+        // NOTE(rob): DEPRECATED, use message_buffer. 8/3/2021
+        // assert.deepStrictEqual(singularEntry[1].writers, expectedSession.writers);
+
+        assert.deepStrictEqual(singularEntry[1].message_buffer, expectedSession.message_buffer);
+
     });   
 
     it("should return failure on getting a nonexistent session", function () {

--- a/test/test-sync.js
+++ b/test/test-sync.js
@@ -22,39 +22,29 @@ const DUMMY_SOCKET_B = { "dummy": "socketB", "id": "LIVEBEEF" };
 const DUMMY_SOCKET_C = { "dummy": "socketC", "id": "SCHRBEEF" };
 
 describe("Sync Server: Sessions", function (done) {
-
     beforeEach(function () {
-
         syncServer.initGlobals();
         
         syncServer.bumpAction = function () { 
-
             throw Error("An unexpected bump occurred.");
-        
         };
         
         syncServer.reconnectAction = function () { 
-
             throw Error("An unexpected reconnect occurred.");
-        
         };
         
         syncServer.disconnectAction = function () { 
-
             throw Error("An unexpected disconnect occurred.");
-        
         };
     });
 
     it("should have 0 sessions on startup", function () {
-        
         let sessions = syncServer.getSessions();
 
         sessions.size.should.equal(0);
     });
 
     it("should create one singular, correct sessions object", function () {
-
         const session_id = 123;
         
         let sessions = syncServer.getSessions();
@@ -72,7 +62,6 @@ describe("Sync Server: Sessions", function (done) {
         // TODO(Brandon) - are we supposed to dip into the syncServer.sessions variable directly like this? 
 
         for (let entry of sessions) {
-
             count += 1;
 
             singularEntry = entry;
@@ -83,7 +72,6 @@ describe("Sync Server: Sessions", function (done) {
         singularEntry[0].should.equal(session_id);
 
         const expectedSession = {
-
             sockets: {}, // socket.id -> client_id
             clients: [],
             entities: [],
@@ -125,7 +113,6 @@ describe("Sync Server: Sessions", function (done) {
     });   
 
     it("should return failure on getting a nonexistent session", function () {
-
         let { success, session } = syncServer.getSession(SESSION_ID);
 
         success.should.equal(false);
@@ -134,7 +121,6 @@ describe("Sync Server: Sessions", function (done) {
     });
 
     it("should return success for getting an existing session", function () {
-
         let inputSession = {
             clients: [ CLIENT_ID ],
             sockets: { 
@@ -155,29 +141,20 @@ describe("Sync Server: Sessions", function (done) {
 });
 
 describe("Sync Server: Clients and Sockets", function (done) {
-
     beforeEach(function () {
-
         syncServer.bumpAction = function () { 
-
             throw Error("An unexpected bump occurred.");
-        
         };
         
         syncServer.reconnectAction = function () { 
-
             throw Error("An unexpected reconnect occurred.");
-        
         };
         
         syncServer.disconnectAction = function () { 
-
             throw Error("An unexpected disconnect occurred.");
-        
         };
 
         syncServer.joinSessionAction = function (session_id, client_id) {
-
             session_id.should.equal(SESSION_ID);
 
             client_id.should.equal(CLIENT_ID);
@@ -190,16 +167,13 @@ describe("Sync Server: Clients and Sockets", function (done) {
 
     /*
     it("should have 0 clients on startup", function () {
-        
     });
     */
 
     it("should append a valid client to an empty session", function () {
-
         let sessions = new Map ();
 
         let session = {
-
             clients: [ ]
         };
 
@@ -215,7 +189,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should create a session when appending a valid client to a null session, appropriately", function () {
-
         let sessions = new Map ();
 
         syncServer.sessions = sessions;
@@ -228,31 +201,19 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should return an error when appending a valid client to a null session, appropriately", function () {
-
         let sessions = new Map ();
 
         syncServer.sessions = sessions;
+        
+        let success = syncServer.addClientToSession(null, CLIENT_ID, false);
 
-        try {
-
-            syncServer.addClientToSession(null, CLIENT_ID, false);
-
-        } catch (err) {
-
-            assert(err.message == "session was null");
-
-            return;
-        }
-
-        assert(false);
+        success.should.eql(false);
     });
 
     it("should append a duplicate client to a session", function () {
-
         let sessions = new Map ();
 
         let session = {
-
             clients: [ CLIENT_ID ]
         };
 
@@ -268,7 +229,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should be able to bump an existing socket", function () {
-
         let session = {
             clients: [ CLIENT_ID, CLIENT_ID, CLIENT_ID ],
             sockets: { }
@@ -289,7 +249,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
         let bumpCount = 0;
 
         syncServer.bumpAction = function (session_id, socket) {
-
             session_id.should.equal(SESSION_ID);
 
             socket.should.be.oneOf(DUMMY_SOCKET_A, DUMMY_SOCKET_B);
@@ -300,7 +259,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
         let disconnectCount = 0;
 
         syncServer.disconnectAction = function (socket, session_id, client_id) {
-
             session_id.should.equal(SESSION_ID);
 
             client_id.should.equal(CLIENT_ID);
@@ -322,7 +280,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should reduce two duplicate clients to one client", function () {
-        
         syncServer.createSession(SESSION_ID);
 
         let { success, session } = syncServer.getSession(SESSION_ID);
@@ -347,7 +304,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should return all session sockets for a given client ID", function () {
-
         syncServer.sessions = new Map ();
 
         let session =  {
@@ -364,7 +320,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
         sockets.should.eql([ DUMMY_SOCKET_A ]);
         
         syncServer.bumpAction = function (session_id, socket) {
-            
             session_id.should.equal(SESSION_ID);
 
             socket.should.eql( { dummy: "socketA", id: "DEADBEEF" } );
@@ -386,7 +341,6 @@ describe("Sync Server: Clients and Sockets", function (done) {
     });
 
     it("should exclude a socket when requesting session sockets", function () {
-
         let session = {
             clients: [ CLIENT_ID, CLIENT_ID, CLIENT_ID ],
             sockets: {
@@ -405,29 +359,20 @@ describe("Sync Server: Clients and Sockets", function (done) {
 });
 
 describe("Sync Server: Integration", function (done) {
-
     beforeEach(function () {
-
         syncServer.bumpAction = function () { 
-
             throw Error("An unexpected bump occurred.");
-        
         };
         
         syncServer.reconnectAction = function () { 
-
             throw Error("An unexpected reconnect occurred.");
-        
         };
         
         syncServer.disconnectAction = function () { 
-
             throw Error("An unexpected disconnect occurred.");
-        
         };
 
         syncServer.joinSessionAction = function (session_id, client_id) {
-
             session_id.should.equal(SESSION_ID);
 
             client_id.should.equal(CLIENT_ID);
@@ -437,7 +382,6 @@ describe("Sync Server: Integration", function (done) {
     });
     
     it("should create a correct session object when a client joins", function () {
-
         let success = syncServer.handleJoin(null, DUMMY_SOCKET_A, SESSION_ID, CLIENT_ID, true);
 
         success.should.equal(true); // we passed in err = null, so it should succeed.
@@ -451,7 +395,6 @@ describe("Sync Server: Integration", function (done) {
         // TODO(Brandon) - are we supposed to dip into the syncServer.sessions variable directly like this? 
 
         for (let entry of sessions) {
-
             singularEntry = entry;
         }
 
@@ -490,7 +433,6 @@ describe("Sync Server: Integration", function (done) {
     });
 
     it("should perform a bump properly", function () {
-
         let success = syncServer.handleJoin(null, DUMMY_SOCKET_A, SESSION_ID, CLIENT_ID, true);
 
         sessions = syncServer.getSessions();
@@ -500,7 +442,6 @@ describe("Sync Server: Integration", function (done) {
         // TODO(Brandon) - are we supposed to dip into the syncServer.sessions variable directly like this? 
 
         for (let entry of sessions) {
-
             singularEntry = entry;
         }
 
@@ -525,14 +466,12 @@ describe("Sync Server: Integration", function (done) {
         // duplicated here
         
         syncServer.bumpAction = function (session_id, socket) {
-            
             session_id.should.equal(SESSION_ID);
 
             socket.should.eql( { dummy: "socketA", id: "DEADBEEF" } );
         };
         
         syncServer.disconnectAction = function (socket, session_id, client_id) {
-
             socket.should.eql( { dummy: "socketA", id: "DEADBEEF" } );
             
             session_id.should.equal(SESSION_ID);
@@ -549,7 +488,6 @@ describe("Sync Server: Integration", function (done) {
         // TODO(Brandon) - are we supposed to dip into the syncServer.sessions variable directly like this? 
 
         for (let entry of sessions) {
-
             singularEntry = entry;
         }
 


### PR DESCRIPTION
# Description

## Fix MySQL edge case

It was possible for the pool to be created but not properly initialized. This is now fixed.

## Split into sync, chat, and admin servers

A single file, serve.js, initializes three socketIO server namespaces and starts up the logger and MySQL pool.

## Add MochaJS tests to sync

Sync server was partially refactored to allow for SocketIO-free unit testing. Brandon created 14 tests and added Istanbul (nyc) for code coverage.

## Port sync to message system

Interactions and position updates now can flow through the message system on the server side.

# Fixes

Partial fix for #11 (needs integration test)
Fixes #12
Fixes #15 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (message system)
- [x] Breaking change (high-efficiency pos/int data capture were deprecated)
- [x] Testing (MochaJS and Istanbul)
- [ ] Change that requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual Test
- [x] Unit Test
- [ ] Integration / End-to-End Test

Untested: 
- [ ] MySQL improper initialization
- [ ] Message system position and interaction data capture 
    - [ ] Drawing
- [ ] #11
- [ ] Overall performance

We will test on the dev server itself.

**Test Configuration**:
* Browser vendor and version: n/a

# Checklist:

- [ ] ~~My code follows the style guidelines of this project~~
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes have no unnecessary logging
- [ ] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Sensitive info like tokens, secrets, and passwords have been removed before submitting
